### PR TITLE
docs: add instructions to disable automatic venv prompt (python)

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -137,6 +137,14 @@ To solely rely on Oh My Posh to set the prompt, you can configure the follwing s
 ```bash
 conda config --set changeps1 False
 ```
+### Python: venv virtual environment's name is auto-added before/after the prompt
+
+Python recommended `venv` library automatically adds virtual environment name to the prompt upon its activation.
+To disable this behaviour and solely rely on Oh My Posh prompt, set `VIRTUAL_ENV_DISABLE_PROMPT` environment variable to `1`.
+
+```powershell
+$env:VIRTUAL_ENV_DISABLE_PROMPT=1
+```
 
 [new-issue]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/new/choose
 [latest]: https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

The docs only include details on disabling the Conda prompt but not the `venv` one for the `Python` segment users of Oh My Posh. This PR introduces the necessary details.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
